### PR TITLE
linuxrc: add utp mass storage setup via configfs

### DIFF
--- a/linuxrc
+++ b/linuxrc
@@ -4,9 +4,26 @@ export PATH=/sbin:/bin:/usr/sbin:/usr/bin
 mount -t sysfs none /sys
 mount -t proc none /proc
 mount -t devtmpfs none /dev
+mount -t configfs none /sys/kernel/config
 
 # disable turn off display
 echo -e "\033[9;0]" > /dev/tty0
+
+# USB UTP setup
+mkdir /sys/kernel/config/usb_gadget/g1
+cd /sys/kernel/config/usb_gadget/g1/
+echo 0x066F > idVendor
+echo 0x37FF > idProduct
+mkdir strings/0x409
+echo 123456ABCDEF > strings/0x409/serialnumber
+echo Freescale > strings/0x409/manufacturer
+echo "FSL i.MX Board" > strings/0x409/product
+mkdir configs/c.1
+echo 5 > configs/c.1/MaxPower
+mkdir functions/mass_storage.1
+ln -s functions/mass_storage.1 configs/c.1/
+echo /fat > functions/mass_storage.1/lun.0/file
+echo ci_hdrc.0 > UDC
 
 cd /home
 


### PR DESCRIPTION
Add utp mass storage setup via configfs

Signed-off-by: Li Jun <jun.li@nxp.com>