### PR TITLE
Fix missing build flags, leading to yocto QA issues

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,14 +1,15 @@
 CC ?= $(CROSS_COMPILE)gcc
 BINDIR ?= /usr/bin
 PROGRAMS = uuc sdimage
+LIBS ?= -lpthread
 
 all: $(PROGRAMS)
 
 uuc: uu.c
-	$(CC) $(CFLAGS) uu.c -o uuc -lpthread
+	$(CC) $(CFLAGS) $(CPPFLAGS) uu.c -o uuc $(LDFLAGS) $(LIBS) 
 
 sdimage: sdimage.c
-	$(CC) $(CFLAGS) sdimage.c -o sdimage
+	$(CC) $(CFLAGS) $(CPPFLAGS) sdimage.c -o sdimage $(LDFLAGS)
 
 install:
 	install -d $(DESTDIR)$(BINDIR)


### PR DESCRIPTION
ERROR: imx-uuc-0.5.1+gitAUTOINC+1de598e7b3-r0 do_package_qa: QA Issue: No GNU_HASH in the elf binary: 'imx-uuc/0.5.1+gitAUTOINC+1de598e7b3-r0/packages-split/imx-uuc/usr/bin/uuc'
No GNU_HASH in the elf binary: 'imx-uuc/0.5.1+gitAUTOINC+1de598e7b3-r0/packages-split/imx-uuc/usr/bin/sdimage' [ldflags]

similar issues have been reported on meta-freescale mail list too and then I'm attaching the Found-by/Signed-off-by flags correspondingly:
(the patches were against meta-freescale, I'm upstreaming them with some little changes)
https://lists.yoctoproject.org/pipermail/meta-freescale/2017-April/020355.html

Found-by: Gianfranco Costamagna <gianfranco.costamagna@abinsula.com>
Found-by: Joel Esponde <Joel.Esponde@Honeywell.com>
Signed-off-by: Bas Mevissen <bas.mevissen@emcodev.nl>