### PR TITLE
linuxrc: improve handling of udc not availble

### DIFF
--- a/linuxrc
+++ b/linuxrc
@@ -9,12 +9,21 @@ mount -t configfs none /sys/kernel/config
 # disable turn off display
 echo -e "\033[9;0]" > /dev/tty0
 
-#Check if there is udc available
-DIRECTORY=/sys/class/udc
-if [ "ls -A $DIRECTORY" = "" ]; then
-echo "No udc available!"
-exit 1
+#Check if there is udc available, if not, wait forever
+UDC_DIR=/sys/class/udc
+while true; do
+if test "$(ls -A "$UDC_DIR")"; then
+	echo "The available udc:"
+	for entry in "$UDC_DIR"/*
+	do
+		echo "$entry"
+	done
+	break;
+else
+	echo "No udc available!"
+	sleep 30
 fi
+done
 
 # USB UTP setup
 mkdir /sys/kernel/config/usb_gadget/g1
@@ -38,7 +47,7 @@ mkdir functions/mass_storage.1
 ln -s functions/mass_storage.1 configs/c.1/
 echo /fat > functions/mass_storage.1/lun.0/file
 
-for udc_name in $(ls $DIRECTORY)
+for udc_name in $(ls $UDC_DIR)
 do
 echo "MFG tool will use 1st udc:$udc_name"
 echo $udc_name > UDC


### PR DESCRIPTION
If there is available udc, list all udc name, if not, we can't go on
so wait it ready, if it can't be ready anyway we wait forever to notify
user the failure reason is udc is not available.

Reviewed-by: Peter Chen <peter.chen@nxp.com>
Signed-off-by: Li Jun <jun.li@nxp.com>