### PR TITLE
Major refactoring for sdimage

### DIFF
--- a/sdimage.c
+++ b/sdimage.c
@@ -202,7 +202,7 @@ int main(int argc, char **argv)
 
 	close(devhandle);
 	close(firmwarehandle);
-	printf("done\r\n");
+	printf("done\n");
 
 	return 0;
 }

--- a/sdimage.c
+++ b/sdimage.c
@@ -23,6 +23,7 @@
 #include <sys/types.h>
 #include <sys/stat.h>
 #include <fcntl.h>
+
 char *g_filedev;
 char *g_firmware;
 
@@ -38,6 +39,7 @@ struct PART {
 	unsigned int start;
 	unsigned int count;
 } __attribute__ ((packed));
+
 struct MBR {
 	unsigned char resevered[446];
 	struct PART part[4];
@@ -75,6 +77,7 @@ int main(int argc, char **argv)
 		printf("sdimage -f <firmware.sb> -d </dev/mmcblk>\n");
 		return -1;
 	}
+
 	for (i = 0; i < argc; i++) {
 		if (strcmp(argv[i], "-f") == 0) {
 			g_firmware = argv[i + 1];
@@ -85,10 +88,12 @@ int main(int argc, char **argv)
 			i++;
 		}
 	}
+
 	if (g_firmware == NULL) {
 		printf("you need give -f <firmware file>\n");
 		return -1;
 	}
+
 	if (g_filedev == NULL) {
 		printf("you need give -d <dev file> \n");
 		return -1;
@@ -105,10 +110,12 @@ int main(int argc, char **argv)
 		printf("can't open file %s\n", g_firmware);
 		return -1;
 	}
+
 	if (stat(g_firmware, &filestat)) {
 		printf("stat %s error\n", g_firmware);
 		return -1;
 	}
+
 	if (read(devhandle, &mbr, sizeof(mbr)) < sizeof(mbr)) {
 		printf("read block 0 fail");
 		return -1;
@@ -188,12 +195,15 @@ int main(int argc, char **argv)
 		return -1;
 	}
 	free(buff);
+
 	if (fsync(devhandle) == -1) {
 		perror("fsync");
 		return -1;
 	}
+
 	close(devhandle);
 	close(firmwarehandle);
 	printf("done\r\n");
+
 	return 0;
 }

--- a/sdimage.c
+++ b/sdimage.c
@@ -25,9 +25,6 @@
 #include <sys/stat.h>
 #include <fcntl.h>
 
-char *g_filedev;
-char *g_firmware;
-
 /* Partition Table Entry */
 struct pte {
 	uint8_t active;
@@ -73,6 +70,8 @@ struct bcb {                                /* (Analogous) Comments from i.MX28 
 
 int main(int argc, char **argv)
 {
+	char *filedev;
+	char *firmware;
 	int i;
 	int devhandle;
 	int firmwarehandle;
@@ -89,39 +88,39 @@ int main(int argc, char **argv)
 
 	for (i = 0; i < argc; i++) {
 		if (strcmp(argv[i], "-f") == 0) {
-			g_firmware = argv[i + 1];
+			firmware = argv[i + 1];
 			i++;
 		}
 		if (strcmp(argv[i], "-d") == 0) {
-			g_filedev = argv[i + 1];
+			filedev = argv[i + 1];
 			i++;
 		}
 	}
 
-	if (g_firmware == NULL) {
+	if (firmware == NULL) {
 		printf("you need give -f <firmware file>\n");
 		return -1;
 	}
 
-	if (g_filedev == NULL) {
+	if (filedev == NULL) {
 		printf("you need give -d <dev file> \n");
 		return -1;
 	}
 
-	devhandle = open(g_filedev, O_RDWR);
+	devhandle = open(filedev, O_RDWR);
 	if (devhandle < 0) {
-		printf("can't open file %s\n", g_filedev);
+		printf("can't open file %s\n", filedev);
 		return -1;
 	}
 
-	firmwarehandle = open(g_firmware, O_RDONLY);
+	firmwarehandle = open(firmware, O_RDONLY);
 	if (firmwarehandle < 0) {
-		printf("can't open file %s\n", g_firmware);
+		printf("can't open file %s\n", firmware);
 		return -1;
 	}
 
-	if (stat(g_firmware, &filestat)) {
-		printf("stat %s error\n", g_firmware);
+	if (stat(firmware, &filestat)) {
+		printf("stat %s error\n", firmware);
 		return -1;
 	}
 

--- a/sdimage.c
+++ b/sdimage.c
@@ -45,20 +45,30 @@ struct mbr {
 	uint16_t signature;
 } __attribute__ ((packed));
 
-struct DeviceInfo {
-	unsigned int u32ChipNum;
-	unsigned int u32DriverType;
-	unsigned int u32Tag;
-	unsigned int u32FirstSectorNumber;
-	unsigned int u32SectorCount;
+/* Drive Info Data Structure */
+struct drive_info {                         /* Comments from i.MX28 RM:                    */
+	uint32_t chip_num;                  /* chip select, ROM does not use it            */
+	uint32_t drive_type;                /* always system drive, ROM does not use it    */
+	uint32_t tag;                       /* drive tag                                   */
+	uint32_t first_sector_number;       /* start sector/block address of firmware      */
+	uint32_t sector_count;              /* not used by ROM                             */
 } __attribute__ ((packed));
 
-struct ConfigBlock {
-	unsigned int u32Sigature;
-	unsigned int u32PrimaryBootTag;
-	unsigned int u32SecondaryBootTags;
-	unsigned int u32NumCopies;
-	struct DeviceInfo aDriverInfo[10];
+/* (maximum) elements in following drive info array
+ * It's a design decision that this tool only supports two elements (at the moment)
+ */
+#define MAX_DI_COUNT 2
+
+/* Boot Control Block (BCB) Data Structure */
+struct bcb {                                /* (Analogous) Comments from i.MX28 RM:        */
+	uint32_t signature;                 /* signature 0x00112233                        */
+	uint32_t primary_boot_tag;          /* primary boot drive identified by this tag   */
+	uint32_t secondary_boot_tag;        /* secondary boot drive identified by this tag */
+	uint32_t num_copies;                /* num elements in drive_info array            */
+	struct drive_info drive_info[MAX_DI_COUNT];
+	                                    /* let drive_info array be last in this data
+	                                     * structure to be able to add more drives in
+	                                     * future without changing ROM code            */
 } __attribute__ ((packed));
 
 int main(int argc, char **argv)
@@ -67,7 +77,7 @@ int main(int argc, char **argv)
 	int devhandle;
 	int firmwarehandle;
 	struct mbr mbr;
-	struct ConfigBlock bcb;
+	struct bcb bcb;
 	char *buff;
 	struct stat filestat;
 	int mincount;
@@ -144,21 +154,21 @@ int main(int argc, char **argv)
 	}
 
 	memset(&bcb, 0, sizeof(bcb));
-	bcb.u32Sigature = 0x00112233;
-	bcb.u32PrimaryBootTag = 1;
-	bcb.u32SecondaryBootTags = 2;
-	bcb.u32NumCopies = 2;
+	bcb.signature = 0x00112233;
+	bcb.primary_boot_tag = 1;
+	bcb.secondary_boot_tag = 2;
+	bcb.num_copies = 2;
 
-	bcb.aDriverInfo[0].u32ChipNum = 0;
-	bcb.aDriverInfo[0].u32DriverType = 0;
-	bcb.aDriverInfo[0].u32Tag = bcb.u32PrimaryBootTag;
-	bcb.aDriverInfo[0].u32FirstSectorNumber = mbr.partition[i].start + 4;
+	bcb.drive_info[0].chip_num = 0;
+	bcb.drive_info[0].drive_type = 0;
+	bcb.drive_info[0].tag = bcb.primary_boot_tag;
+	bcb.drive_info[0].first_sector_number = mbr.partition[i].start + 4;
 
-	bcb.aDriverInfo[1].u32ChipNum = 0;
-	bcb.aDriverInfo[1].u32DriverType = 0;
-	bcb.aDriverInfo[1].u32Tag = bcb.u32SecondaryBootTags;
-	bcb.aDriverInfo[1].u32FirstSectorNumber =
-	    bcb.aDriverInfo[0].u32FirstSectorNumber
+	bcb.drive_info[1].chip_num = 0;
+	bcb.drive_info[1].drive_type = 0;
+	bcb.drive_info[1].tag = bcb.secondary_boot_tag;
+	bcb.drive_info[1].first_sector_number =
+	    bcb.drive_info[0].first_sector_number
 	    + ((filestat.st_size + 511) / 512);
 
 	lseek(devhandle, mbr.partition[i].start * 512, SEEK_SET);
@@ -180,7 +190,7 @@ int main(int argc, char **argv)
 
 	printf("write first firmware\n");
 
-	lseek(devhandle, bcb.aDriverInfo[0].u32FirstSectorNumber * 512, SEEK_SET);
+	lseek(devhandle, bcb.drive_info[0].first_sector_number * 512, SEEK_SET);
 	if (write(devhandle, buff, filestat.st_size) != filestat.st_size) {
 		printf("first firmware write fail\n");
 		return -1;
@@ -188,7 +198,7 @@ int main(int argc, char **argv)
 
 	printf("write second firmware\n");
 
-	lseek(devhandle, bcb.aDriverInfo[1].u32FirstSectorNumber * 512, SEEK_SET);
+	lseek(devhandle, bcb.drive_info[1].first_sector_number * 512, SEEK_SET);
 	if (write(devhandle, buff, filestat.st_size) != filestat.st_size) {
 		printf("second firmware write fail\n");
 		return -1;

--- a/sdimage.c
+++ b/sdimage.c
@@ -63,7 +63,7 @@ struct ConfigBlock {
 
 int main(int argc, char **argv)
 {
-	int i = 0;
+	int i;
 	int devhandle;
 	int firmwarehandle;
 	struct mbr mbr;


### PR DESCRIPTION
While there are alternative tools out there (e.g. mxsboot from U-Boot), I'm still using sdimage when creating SD cards and/or eMMC images because it is capable of writing primary and secondary boot streams (compared to e.g. mxsboot).
However, I always regretted that this tool looks like a quick hack and was not coded with care (IMHO).
But I think is important to have a clean code base, because when the tool is run in target system and used to update the bootloader, then this is critical and this tool should be easy to debug and maintain.
That's why I created this patch series.