### PR TITLE
Printf fixes

### DIFF
--- a/sdimage.c
+++ b/sdimage.c
@@ -305,7 +305,8 @@ int main(int argc, char *argv[])
 	}
 
 	if (verbose > 1) {
-		printf("Firmware size: %ld bytes, %ld sectors\n", fw_stat.st_size, SECTOR_COUNT(fw_stat.st_size));
+		printf("Firmware size: %lld bytes, %lld sectors\n",
+		       (long long int)fw_stat.st_size, (long long int)SECTOR_COUNT(fw_stat.st_size));
 	}
 
 	/* open target device and read MBR with partition table */

--- a/ufb.c
+++ b/ufb.c
@@ -490,7 +490,7 @@ int handle_cmd(const char *cmd)
 			memset(&st, 0, sizeof(st));
 			stat(file, &st);
 			size = st.st_size;
-			sprintf(fm.data, "%016lX", size);
+			sprintf(fm.data, "%016zX", size);
 			rz = 4 + strlen(fm.data);
 		}
 


### PR DESCRIPTION
This fixes compiler warnings about printf arguments type mismatch.