### PR TITLE
fix build break for makedev macro

### DIFF
--- a/uu.c
+++ b/uu.c
@@ -27,6 +27,7 @@
 #include <fcntl.h>
 #include <sys/stat.h>
 #include <sys/types.h>
+#include <sys/sysmacros.h>
 #include <sys/ioctl.h>
 #include <string.h>
 #include <malloc.h>
@@ -55,7 +56,7 @@
 #pragma pack(1)
 
 #define PACKAGE "uuc"
-#define VERSION "0.5"
+#define VERSION "0.6"
 
 char *utp_firmware_version = "2.6.31";
 char *utp_sn = "000000000000";


### PR DESCRIPTION
GNU C library moved the makedev macro from sys/types.h to
sys/sysmacros.h . Include the later header file to fix the build break.

uu.c: In function 'utp_mk_devnode':
uu.c:133:34: warning: implicit declaration of function 'makedev' [-Wimplicit-function-declaration]
     rc = mknod(node, type | 0666, makedev(major, minor));
                     ^~~~~~~

Signed-off-by: Han Xu <han.xu@nxp.com>