### PR TITLE
ufb: fix nitpick regarding format argument

### DIFF
--- a/ufb.c
+++ b/ufb.c
@@ -538,7 +538,7 @@ int handle_cmd(const char *cmd)
 			key = FAIL;
 
 		if (rs != size) {
-			printf("read size %ld != %d\n", rs, size);
+			printf("read size %zd != %d\n", rs, size);
 			key = FAIL;
 		}
 


### PR DESCRIPTION
This fixes the following compiler warning:

---8<---
ufb.c: In function 'handle_cmd':
ufb.c:541:45: warning: format '%ld' expects argument of type 'long int', but argument 2 has type 'ssize_t' {aka 'int'} [-Wformat=]
  541 |                         printf("read size %ld != %d\n", rs, size);
      |                                           ~~^           ~~
      |                                             |           |
      |                                             long int    ssize_t {aka int}
      |                                           %d
---8<---