### PR TITLE
ufb: fix bcdVersion to 0x0100

### DIFF
--- a/ufb.c
+++ b/ufb.c
@@ -179,7 +179,7 @@ static const struct usb_fs_desc g_descriptors = {
 		.interface = cpu_to_le32(1),
 		.dwLength = cpu_to_le32(sizeof(g_descriptors.os_header)
 		                        + sizeof(g_descriptors.os_desc)),
-		.bcdVersion = cpu_to_le32(1),
+		.bcdVersion = cpu_to_le32(0x0100),
 		.wIndex = cpu_to_le32(4),
 		.bCount = cpu_to_le32(1),
 		.Reserved = cpu_to_le32(0),
@@ -198,7 +198,7 @@ static const struct usb_fs_desc g_descriptors = {
 		                        + sizeof(g_descriptors.property_name)
 		                        + sizeof(g_descriptors.property_data_len)
 		                        + sizeof(g_descriptors.property_data)),
-		.bcdVersion = cpu_to_le32(1),
+		.bcdVersion = cpu_to_le32(0x0100),
 		.wIndex = cpu_to_le32(5),
 		.wCount = 1,
 	},


### PR DESCRIPTION
bcdVersion in USB gadget framework is 0x0100 and updated with [1] in the kernel. Fix the warning by using 0x0100 as bcdVersion.

[1]: https://lore.kernel.org/all/290f96db-1877-5137-373a-318e7b4f2dde@lineo.co.jp/