### PR TITLE
linuxrc: Update CRRM ethernet interface

### DIFF
--- a/linuxrc
+++ b/linuxrc
@@ -150,7 +150,12 @@ function launch_crrm() {
 		server=($server)
 		server=${server[0]}
 
-		udhcpc -i eth1
+		interfaces=$(ip -o link show | grep "link/ether" | grep -v "master" | awk -F': ' '{print $2}')
+		for interface in $interfaces; do
+			if udhcpc -i "$interface" -n; then
+				break;
+			fi
+		done
 		echo "Start tftp download"
 		tftp -g -r flash.bin ${server}
 


### PR DESCRIPTION
Change to not use fixed ethernet interface, but Loop through each interface for udhcpc. So CRRM can use any enabled interface.